### PR TITLE
provide easy access for 3rd party plugins to UnityExplorer's Inspector

### DIFF
--- a/src/Utility/MiscUtility.cs
+++ b/src/Utility/MiscUtility.cs
@@ -8,6 +8,10 @@ namespace UniverseLib.Utility
 {
     public static class MiscUtility
     {
+        private static bool isFirstCallToInspect = true;
+        private static Type inspectorManagerType;
+        private static Type cacheObjectBaseType;
+        
         /// <summary>
         /// Check if a string contains another string, case-insensitive.
         /// </summary>
@@ -42,6 +46,43 @@ namespace UniverseLib.Utility
                     return false;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Tells whether UnityExplorer plugin is currently loaded or not.
+        /// </summary>
+        /// <returns></returns>
+        public static bool CanInspect() => !isFirstCallToInspect
+            ? inspectorManagerType != null
+            : (isFirstCallToInspect = false) !=
+              ((inspectorManagerType = ReflectionUtility.GetTypeByName("UnityExplorer.InspectorManager")) != null);
+
+        /// <summary>
+        /// Sends a type to open in a new tab of UnityExplorer's Inspector, if available.
+        /// </summary>
+        /// <param name="type">a Type to inspect</param>
+        public static void Inspect(Type type)
+        {
+            if (!CanInspect())
+                return;
+
+            inspectorManagerType.GetMethod("Inspect", ReflectionUtility.FLAGS, null, 
+                new Type[] {typeof(Type)}, null)?.Invoke(null, new object[] {type});
+        }
+
+        /// <summary>
+        /// Sends an object to UnityExplorer's Inspector, if available.
+        /// </summary>
+        /// <param name="obj">an object to inspect</param>
+        public static void Inspect(object obj, object sourceCache = null)
+        {
+            if (!CanInspect())
+                return;
+            
+            cacheObjectBaseType ??= ReflectionUtility.GetTypeByName("UnityExplorer.CacheObject.CacheObjectBase");
+
+            inspectorManagerType.GetMethod("Inspect", ReflectionUtility.FLAGS, null,
+                new Type[] {typeof(object), cacheObjectBaseType}, null)?.Invoke(null, new object[] {obj, sourceCache});
         }
     }
 }


### PR DESCRIPTION
Hey!

Allows other plugin developers that make use of UniverseLib to send any object/type to UnityExplorer's Inspector when the UnityExplorer plugin is also loaded.

I'm a mess naming things so feel free to rename/refactor it your way.

Thank you! You've got quite a pair in modding tools =)