### PR TITLE
Use Assembly.LoadFrom to ensure interop assemblies are loaded

### DIFF
--- a/src/Reflection/Il2CppReflection.cs
+++ b/src/Reflection/Il2CppReflection.cs
@@ -641,14 +641,7 @@ namespace UniverseLib
             try
             {
                 //Universe.Log($"Loading assembly '{Path.GetFileName(fullPath)}'");
-#if INTEROP
-                // Using LoadFile (on .NET Core 1.0+) will load the Assembly in a new AssemblyLoadContext
-                // which leads to unexpected behavior in Il2CppInterop due to multiple 
-                // of the same assembly being loaded in the runtime.
                 Assembly.LoadFrom(fullPath);
-#else
-                Assembly.LoadFile(fullPath);
-#endif
                 return true;
             }
             catch

--- a/src/Reflection/Il2CppReflection.cs
+++ b/src/Reflection/Il2CppReflection.cs
@@ -641,7 +641,14 @@ namespace UniverseLib
             try
             {
                 //Universe.Log($"Loading assembly '{Path.GetFileName(fullPath)}'");
+#if INTEROP
+                // Using LoadFile (on .NET Core 1.0+) will load the Assembly in a new AssemblyLoadContext
+                // which leads to unexpected behavior in Il2CppInterop due to multiple 
+                // of the same assembly being loaded in the runtime.
+                Assembly.LoadFrom(fullPath);
+#else
                 Assembly.LoadFile(fullPath);
+#endif
                 return true;
             }
             catch


### PR DESCRIPTION
## Context
Assembly.LoadFile will load the assembly in a new AssemblyLoadContext, which causes unexpected behavior on Il2CppInterop (& Unhollower)

A [similar issue was recently resolved on BepInEx](https://github.com/BepInEx/BepInEx/commit/b9fe50767290ec8d133e836e9083af315a9d4551)

## Relevant issues
sinai-dev/UnityExplorer#158

> it is finding two types called `Il2CppSystem.Byte` in `Il2Cppmscorlib`

Due to UniverseLib accidentally loading a second Il2Cppmscorlib into the runtime, Il2CppInterop fails on the `Single` call due to there being more than one assembly.