### PR TITLE
Safely handle external Namespace acquisition in CacheTypes

### DIFF
--- a/src/Input/InputManager.cs
+++ b/src/Input/InputManager.cs
@@ -49,6 +49,7 @@ namespace UniverseLib.Input
                 } 
             }
 
+            string last_error = "";
             if (LegacyInput.TInput != null)
             {
                 try
@@ -62,9 +63,10 @@ namespace UniverseLib.Input
                     Universe.Log("Initialized Legacy Input support");
                     return;
                 }
-                catch 
+                catch (Exception ex)
                 {
                     // It's not working, we'll fall back to InputSystem.
+                    last_error += '\n' + ex.Message;
                 }
             }
 
@@ -79,11 +81,11 @@ namespace UniverseLib.Input
                 }
                 catch (Exception ex)
                 {
-                    Universe.Log(ex);
+                    last_error += '\n' + ex.Message;
                 }
             }
 
-            Universe.LogWarning("Could not find any Input Module Type!");
+            Universe.LogWarning($"Could not find any Input Module Type:\n{last_error}");
             inputHandler = new NoInput();
             CurrentType = InputType.None;
         }


### PR DESCRIPTION
And additionally collect reason for keyboard processing error on `InitHandler` failure. 

The reason - because otherwise it fails with `BepInEx-Unity.IL2CPP-win-x64-6.0.0-be.656` and `Unity 2020.3.38f1` with `Namespace` access crashes on a few methods.